### PR TITLE
Enable additional parameters in port mapping

### DIFF
--- a/src/schemas/marathon/app/portMapping.js
+++ b/src/schemas/marathon/app/portMapping.js
@@ -5,7 +5,7 @@
 module.exports = {
   type: 'object',
   required: ['containerPort', 'hostPort', 'protocol'],
-  additionalProperties: false,
+  additionalProperties: true,
   properties: {
     containerPort: {
       type: 'integer'


### PR DESCRIPTION
I changed the `additionalProperties` option in portMappings schema because there may be some more options. As an example I need to use `labels.VIP_0` to enable DC/OS internal load balancing.